### PR TITLE
Dev PI

### DIFF
--- a/codes/classes/dataAPI.py
+++ b/codes/classes/dataAPI.py
@@ -81,6 +81,7 @@ class dataAPI:
         self.partners = config["partners"]
         self.period = getPeriod(frequency=self.frequency, years=self.years, months=self.months)
         self.data_path = getFolder("data")
+        self.stata_files = config["stata_files"]
 
     def fetch_data(self):
         """
@@ -101,9 +102,11 @@ class dataAPI:
                             directory=self.data_path,
                             frequency=self.frequency,
                             period=period,
-                            reporter=Reporter(name=country,
-                                              code=self.countries.get(country)
-                                              ),
+                            reporter=Reporter(
+                                name=country,
+                                code=self.countries.get(country)
+                            ),
+                            stata_files=self.stata_files,
                             # TODO: to reactivate
                             # flow=self.flows,
                             # partners=self.partners,

--- a/codes/classes/dataAPI.py
+++ b/codes/classes/dataAPI.py
@@ -8,7 +8,7 @@ from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 from typing import Union
 import unicodedata
-from codes.functions.getData import getData, checkStatus
+from codes.functions.getData import getData, checkStatus, singleFileAggregation
 from codes.settings import config
 
 def get_session_with_retries():
@@ -83,6 +83,7 @@ class dataAPI:
         self.data_path = getFolder("data")
         self.stata_files = config["stata_files"]
         self.typeCode = config["typeCode"]
+        self.single_file = config["single_file"]
 
     def fetch_data(self):
         """
@@ -119,6 +120,16 @@ class dataAPI:
                     logging.info(f"Data for {country} for period {period} fetched successfully.")
                 except Exception as e:
                     logging.error(f"Failed to fetch data for {country} for period {period}: {e}")
+            # Check if a single file is requested (only for bulk method for now)
+            # TODO: implement for batch method
+            if self.single_file and self.method == "bulk":
+                logging.info("Aggregating data across countries into a single file...")
+                singleFileAggregation(
+                    directory=self.data_path,
+                    frequency=self.frequency,
+                    period=period,
+                    typeCode=self.typeCode,
+                )
         return data
 
     def __repr__(self):

--- a/codes/classes/dataAPI.py
+++ b/codes/classes/dataAPI.py
@@ -82,6 +82,7 @@ class dataAPI:
         self.period = getPeriod(frequency=self.frequency, years=self.years, months=self.months)
         self.data_path = getFolder("data")
         self.stata_files = config["stata_files"]
+        self.typeCode = config["typeCode"]
 
     def fetch_data(self):
         """
@@ -107,6 +108,7 @@ class dataAPI:
                                 code=self.countries.get(country)
                             ),
                             stata_files=self.stata_files,
+                            typeCode=self.typeCode,
                             # TODO: to reactivate
                             # flow=self.flows,
                             # partners=self.partners,

--- a/codes/classes/dataCall.py
+++ b/codes/classes/dataCall.py
@@ -47,7 +47,7 @@ class dataCall:
         # Get data
         for country in countries:
             # TODO: implement a check if flow exists
-            flows = list(map(lambda flow: country / 'Parquet' / flow, self.flows))
+            flows = list(map(lambda flow: country / 'Parquet' / flow / 'C', self.flows))
             # Loop over flows
             for flow in flows:
                 files = flow.glob('*.parquet.gzip')

--- a/codes/functions/getData.py
+++ b/codes/functions/getData.py
@@ -289,150 +289,153 @@ flows = {
 
 # TODO: delete flows
 # TODO: code refactoring need
-def bulkMethod(key: str, directory: str, frequency: str, period: str, reporter: tuple):
-   """
-   @key: str
-   @directory: str
-   @frequency: str
-   @period: str
-   @reporter: tuple
-   
-   Retrieve data in bulk. Access to the premium API is required.
-   """
-   
-   try:
-       os.mkdir(os.path.join(directory, reporter.name))
-   except FileExistsError:
-       pass
-   
-   # Temp directory to store text files
-   temp_directory = TemporaryDirectory(dir = os.path.join(directory, reporter.name))
-   
-   request =  comtradeapicall.bulkDownloadFinalFile(
-                                                    subscription_key = key,
-                                                    directory = temp_directory.name,
-                                                    # Goods
-                                                    typeCode = 'C',
-                                                    freqCode = frequency,
-                                                    # Harmonised System
-                                                    clCode = 'HS',
-                                                    period = period,
-                                                    reporterCode = reporter.code,
-                                                    decompress = True
-                                                    )
-   
-   # Get files based on relative path and file extension to be filtered
-   files = glob.glob(f'{temp_directory.name}/**.txt')
-   
-   # Folders where to store the data
-   folders = ['Parquet','Stata']
-   
-   for file in files:
-       data = pd.read_csv(file, sep = '\t', dtype = {'cmdCode': str}).groupby(['flowCode'])
-       for g in data.groups:
-           
-           for f in folders:
-               try:
-                   os.makedirs(os.path.join(directory,reporter.name,f,flows.get(g)))
-               except FileExistsError:
-                   pass
-           
-           df = data.get_group(g).sort_values(by = ['primaryValue'], ascending = False)
+def bulkMethod(key: str, directory: str, frequency: str, period: str, reporter: tuple, stata_files: bool):
+    """
+    @key: str
+    @directory: str
+    @frequency: str
+    @period: str
+    @reporter: tuple
+    @stata_files: bool
+    
+    Retrieve data in bulk. Access to the premium API is required.
+    """
+    
+    try:
+        os.mkdir(os.path.join(directory, reporter.name))
+    except FileExistsError:
+        pass
+    
+    # Temp directory to store text files
+    temp_directory = TemporaryDirectory(dir = os.path.join(directory, reporter.name))
+    
+    request =  comtradeapicall.bulkDownloadFinalFile(
+        subscription_key = key,
+        directory = temp_directory.name,
+        # Goods
+        typeCode = 'C',
+        freqCode = frequency,
+        # Harmonised System
+        clCode = 'HS',
+        period = period,
+        reporterCode = reporter.code,
+        decompress = True
+    )
+
+    # Get files based on relative path and file extension to be filtered
+    files = glob.glob(f'{temp_directory.name}/**.txt')
+
+    # Folders where to store the data
+    folders = ['Parquet','Stata'] if stata_files else ['Parquet']
+
+    for file in files:
+        data = pd.read_csv(file, sep = '\t', dtype = {'cmdCode': str}).groupby(['flowCode'])
+        for g in data.groups:
+            
+            for f in folders:
+                try:
+                    os.makedirs(os.path.join(directory,reporter.name,f,flows.get(g)))
+                except FileExistsError:
+                    pass
+            
+            df = data.get_group(g).sort_values(by = ['primaryValue'], ascending = False)
             
             # Write files
             # Stata          
-           t = df['period'].drop_duplicates().to_string(index = False)
-           if len(str(t)) > 4:
-               t = str(t)[:4] + '_' + str(t)[-2:]
-           else:
-               t = str(t)
-           
-               
-           df.to_stata(
-                        path = f'{os.path.join(directory, reporter.name, "Stata", flows.get(g), t + ".dta")}',
-                        # version = 117,
-                        # Prevent to block writing process if columns are fully empty
-                        # convert_strl = df.columns[df.isnull().all()].to_list()
-                        )
+            t = df['period'].drop_duplicates().to_string(index = False)
+            if len(str(t)) > 4:
+                t = str(t)[:4] + '_' + str(t)[-2:]
+            else:
+                t = str(t)
+
+            if stata_files:
+                df.to_stata(
+                    path = f'{os.path.join(directory, reporter.name, "Stata", flows.get(g), t + ".dta")}',
+                    # version = 117,
+                    # Prevent to block writing process if columns are fully empty
+                    # convert_strl = df.columns[df.isnull().all()].to_list()
+                )
             # Parquet
-           df.to_parquet(path = f'{os.path.join(directory, reporter.name, "Parquet", flows.get(g), t + ".parquet.gzip")}', compression = 'gzip') 
-             
-   return request
-   
+            df.to_parquet(path = f'{os.path.join(directory, reporter.name, "Parquet", flows.get(g), t + ".parquet.gzip")}', compression = 'gzip') 
+
+    return request
+
 def batchMethod(key: str, 
-                directory: str, 
-                frequency: str, 
-                period: str, 
-                reporter: str,
-                hscode: int,
-                flow: str, 
-                partners: list
-                ):
-   """
-   @key:str
-   @frequency: str
-   @period: str
-   @reporter: str
-   @sector: int
-   @flow: str
-   @partners: list
-          
-   Retrieve data in small batches.
-   """
-   
-   # Temp directory
-   # To prevent disconnection from the network drive
-   temp_directory = TemporaryDirectory(dir = os.path.join(directory,reporter))
-   
-   # HS codes
-   if hscode == 2:
-       codes = [f'{c:>02}' for c in range(1,99+1)] + ['TOTAL']
-   elif hscode == 4:
-       codes = [''.join(c) for c in list(product([f'{c:>02}' for c in range(1,99+1)],[f'{c:>02}' for c in range(1,99+1)]))]
-   
-   for code in codes:
-       
-       request = comtradeapicall._getFinalData(
-                                              subscription_key = key,
-                                              typeCode ='C', 
-                                              freqCode = frequency,
-                                              clCode = 'HS',
-                                              period = period,
-                                              reporterCode = countries.get(reporter),
-                                              cmdCode = code,                                               
-                                              flowCode = flow,
-                                              partnerCode = ','.join([countries.get(p) for p in partners]),
-                                              partner2Code=None,
-                                              customsCode=None, 
-                                              motCode=None, 
-                                              # maxRecords=250000, 
-                                              format_output='JSON',
-                                              aggregateBy=None, 
-                                              breakdownMode='classic', 
-                                              countOnly=None, 
-                                              includeDesc=True
-                                              )
-       
-       if not request.empty:
-           request.to_parquet(path = f'{os.path.join(temp_directory.name, code + ".parquet.gzip")}', compression = 'gzip')
-           logging.info(f'Code {code} successfully downloaded.')
-       else:
-           logging.info(f'No data for code {code}.')
-           
-   # Get files based on relative path and file extension to be filtered
-   files = glob.glob(f'{temp_directory.name}/**.parquet.gzip')
-        
-   # Folders where to store the data
-   folders = ['Parquet','Stata']
-   
-   data = []
-   
-   for file in files:
-       data.append(pd.read_parquet(file))
-       
-   data = pd.concat(data).groupby(by = ['flowCode', 'period'])
+    directory: str, 
+    frequency: str, 
+    period: str, 
+    reporter: str,
+    hscode: int,
+    flow: str, 
+    partners: list,
+    stata_files: bool
+):
+    """
+    @key:str
+    @frequency: str
+    @period: str
+    @reporter: str
+    @sector: int
+    @flow: str
+    @partners: list
+    @stata_files: bool
+
+    Retrieve data in small batches.
+    """
+
+    # Temp directory
+    # To prevent disconnection from the network drive
+    temp_directory = TemporaryDirectory(dir = os.path.join(directory,reporter))
+
+    # HS codes
+    if hscode == 2:
+        codes = [f'{c:>02}' for c in range(1,99+1)] + ['TOTAL']
+    elif hscode == 4:
+        codes = [''.join(c) for c in list(product([f'{c:>02}' for c in range(1,99+1)],[f'{c:>02}' for c in range(1,99+1)]))]
     
-   for g in data.groups:
+    for code in codes:
+
+        request = comtradeapicall._getFinalData(
+            subscription_key = key,
+            typeCode ='C', 
+            freqCode = frequency,
+            clCode = 'HS',
+            period = period,
+            reporterCode = countries.get(reporter),
+            cmdCode = code,                                               
+            flowCode = flow,
+            partnerCode = ','.join([countries.get(p) for p in partners]),
+            partner2Code=None,
+            customsCode=None, 
+            motCode=None, 
+            # maxRecords=250000, 
+            format_output='JSON',
+            aggregateBy=None, 
+            breakdownMode='classic', 
+            countOnly=None, 
+            includeDesc=True
+        )
+
+        if not request.empty:
+            request.to_parquet(path = f'{os.path.join(temp_directory.name, code + ".parquet.gzip")}', compression = 'gzip')
+            logging.info(f'Code {code} successfully downloaded.')
+        else:
+            logging.info(f'No data for code {code}.')
+
+    # Get files based on relative path and file extension to be filtered
+    files = glob.glob(f'{temp_directory.name}/**.parquet.gzip')
+        
+    # Folders where to store the data
+    folders = ['Parquet','Stata'] if stata_files else ['Parquet']
+
+    data = []
+
+    for file in files:
+        data.append(pd.read_parquet(file))
+        
+    data = pd.concat(data).groupby(by = ['flowCode', 'period'])
+    
+    for g in data.groups:
         
         for f in folders:
             try:
@@ -449,19 +452,19 @@ def batchMethod(key: str,
             t = str(t)[:4] + '_' + str(t)[-2:]
         else:
             t = str(t)
-        
-            
-        df.to_stata(
-                     path = f'{os.path.join(directory, reporter, "Stata", flows.get(g[0][0]), t + ".dta")}',
-                     version = 117,
-                     # Prevent to block writing process if columns are fully empty
-                     # convert_strl = df.columns[df.isnull().all()].to_list()
-                     )
-         # Parquet
+
+        if stata_files:
+            df.to_stata(
+                path = f'{os.path.join(directory, reporter, "Stata", flows.get(g[0][0]), t + ".dta")}',
+                version = 117,
+                # Prevent to block writing process if columns are fully empty
+                # convert_strl = df.columns[df.isnull().all()].to_list()
+            )
+        # Parquet
         df.to_parquet(path = f'{os.path.join(directory, reporter, "Parquet", flows.get(g[0][0]), t + ".parquet.gzip")}', compression = 'gzip')   
-   
-   
-   return request
+    
+    
+    return request
 
 
 funcs = {

--- a/codes/functions/getData.py
+++ b/codes/functions/getData.py
@@ -289,7 +289,7 @@ flows = {
 
 # TODO: delete flows
 # TODO: code refactoring need
-def bulkMethod(key: str, directory: str, frequency: str, period: str, reporter: tuple, stata_files: bool):
+def bulkMethod(key: str, directory: str, frequency: str, period: str, reporter: tuple, stata_files: bool, typeCode: str):
     """
     @key: str
     @directory: str
@@ -297,6 +297,7 @@ def bulkMethod(key: str, directory: str, frequency: str, period: str, reporter: 
     @period: str
     @reporter: tuple
     @stata_files: bool
+    @typeCode: str
     
     Retrieve data in bulk. Access to the premium API is required.
     """
@@ -313,7 +314,7 @@ def bulkMethod(key: str, directory: str, frequency: str, period: str, reporter: 
         subscription_key = key,
         directory = temp_directory.name,
         # Goods
-        typeCode = 'C',
+        typeCode = typeCode,
         freqCode = frequency,
         # Harmonised System
         clCode = 'HS',
@@ -334,7 +335,7 @@ def bulkMethod(key: str, directory: str, frequency: str, period: str, reporter: 
             
             for f in folders:
                 try:
-                    os.makedirs(os.path.join(directory,reporter.name,f,flows.get(g)))
+                    os.makedirs(os.path.join(directory,reporter.name,f,typeCode,flows.get(g)))
                 except FileExistsError:
                     pass
             
@@ -350,13 +351,13 @@ def bulkMethod(key: str, directory: str, frequency: str, period: str, reporter: 
 
             if stata_files:
                 df.to_stata(
-                    path = f'{os.path.join(directory, reporter.name, "Stata", flows.get(g), t + ".dta")}',
+                    path = f'{os.path.join(directory, reporter.name, "Stata", typeCode, flows.get(g), t + ".dta")}',
                     # version = 117,
                     # Prevent to block writing process if columns are fully empty
                     # convert_strl = df.columns[df.isnull().all()].to_list()
                 )
             # Parquet
-            df.to_parquet(path = f'{os.path.join(directory, reporter.name, "Parquet", flows.get(g), t + ".parquet.gzip")}', compression = 'gzip') 
+            df.to_parquet(path = f'{os.path.join(directory, reporter.name, "Parquet", typeCode, flows.get(g), t + ".parquet.gzip")}', compression = 'gzip') 
 
     return request
 
@@ -368,7 +369,8 @@ def batchMethod(key: str,
     hscode: int,
     flow: str, 
     partners: list,
-    stata_files: bool
+    stata_files: bool,
+    typeCode: str
 ):
     """
     @key:str
@@ -379,6 +381,7 @@ def batchMethod(key: str,
     @flow: str
     @partners: list
     @stata_files: bool
+    @typeCode: str
 
     Retrieve data in small batches.
     """
@@ -397,7 +400,7 @@ def batchMethod(key: str,
 
         request = comtradeapicall._getFinalData(
             subscription_key = key,
-            typeCode ='C', 
+            typeCode = typeCode, 
             freqCode = frequency,
             clCode = 'HS',
             period = period,
@@ -439,7 +442,7 @@ def batchMethod(key: str,
         
         for f in folders:
             try:
-                os.makedirs(os.path.join(directory,reporter,f,flows.get(g[0][0])))
+                os.makedirs(os.path.join(directory,reporter,f,typeCode,flows.get(g[0][0])))
             except FileExistsError:
                 pass
         
@@ -455,13 +458,13 @@ def batchMethod(key: str,
 
         if stata_files:
             df.to_stata(
-                path = f'{os.path.join(directory, reporter, "Stata", flows.get(g[0][0]), t + ".dta")}',
+                path = f'{os.path.join(directory, reporter, "Stata", typeCode, flows.get(g[0][0]), t + ".dta")}',
                 version = 117,
                 # Prevent to block writing process if columns are fully empty
                 # convert_strl = df.columns[df.isnull().all()].to_list()
             )
         # Parquet
-        df.to_parquet(path = f'{os.path.join(directory, reporter, "Parquet", flows.get(g[0][0]), t + ".parquet.gzip")}', compression = 'gzip')   
+        df.to_parquet(path = f'{os.path.join(directory, reporter, "Parquet", typeCode, flows.get(g[0][0]), t + ".parquet.gzip")}', compression = 'gzip')   
     
     
     return request

--- a/codes/settings.py
+++ b/codes/settings.py
@@ -59,5 +59,7 @@ config = {
     # Choose between 2 and 4 (6 to be implemented)
     "hscode": 2,
     # Choose whether to write stata files or not (True/False)
-    "stata_files": True,
+    "stata_files": False,
+    # Choose  whether to write a single file with all reports and flows or not (True/False)
+    "single_file": True,
 }

--- a/codes/settings.py
+++ b/codes/settings.py
@@ -41,6 +41,9 @@ config = {
     "api_key": api_key,  # Fetch API key from environment variable
     # Choose between 'bulk' or 'batch'
     "method": "bulk",
+    # Choose typeCode 'C' for commodity or 'S' for service
+    # NOTE: 'S' is available only for 'A' (Annual) frequency so select 'A' below
+    "typeCode": "C",
     # Choose between 'A' (Annual) and 'M' (Monthly)
     "frequency": "M",
     # 'X' for exports, 'M' for imports

--- a/codes/settings.py
+++ b/codes/settings.py
@@ -55,4 +55,6 @@ config = {
     "months": list(range(1, 12 + 1)),
     # Choose between 2 and 4 (6 to be implemented)
     "hscode": 2,
+    # Choose whether to write stata files or not (True/False)
+    "stata_files": True,
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ fastparquet # For parquet files
 linearmodels  # For panel regression models
 numpy  # For numerical computations
 pandas  # For data manipulation and analysis
+polars # For fast DataFrame operations
 pyarrow # For parquet files
 python-dotenv # For environment variables
 requests  # For making HTTP requests


### PR DESCRIPTION
Hi Luca,

Find below my suggested changed for the three issues I have opened in your repository.

- The commit f5296fc509b4a999ad6ce3e3bd8c993fee01a792 is for the optional writing of Stata files, managed using a boolean in the settings file.
- The commit e162d7f7c27f4631a6ea72bcd0bc775dc24606cf is for the optional choice of code type linked to commodity or services, this is also in the settings file now (the services require the frequency to be annual).
- The commit 1a09bfa78896e25b612ba37d2a225d7f24c7b4fe is a bit more significant and it aggregates the files for a given period and flow across countries. Whether to realize the aggregation or not is also set by a boolean in the settings file.

A bit more details on the last commit as I think it is the more complex aspect to introduce. The aggregation of files is done using the Polars library, which I find to be faster and less memory intensive for this task compared to Pandas (at least the way i tried to implement both). The library has been added to the requirements for the venv. Also notice that the "C" or "S" is now part of the depth of the directories to store separately exports, imports, etc. for different typeCode.

There is a different way to implement the single file which would be to provide an option that instead of downloading the files by reporter (the part you had in the code) executes the API request with "None" as reporter code. This way all reporters are downloaded for a given reference, codetype, etc. and can be included in a glob to be loaded in memory and concatenated together. I think this way might have more severe memory requirements than the one you will find here. However, feel free to try it out if you think it might be better. 

Some further testing is required but so far the few attempts  I had with annual and monthly commodity data had no bugs.